### PR TITLE
Improve visuals and reliability

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3,14 +3,17 @@ html, body {
     padding: 0;
     width: 100%;
     height: 100%;
-    background-color: #000;
+    background: linear-gradient(#222, #000);
     overflow: hidden;
-    font-family: 'Helvetica Neue','Arial','sans-serif';
+    font-family: 'Helvetica Neue', 'Arial', sans-serif;
 }
 
 #game-container {
     width: 100%;
     height: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
     touch-action: none;
     -webkit-tap-highlight-color: transparent;
 }
@@ -20,12 +23,18 @@ button {
     padding: 0.8rem 1.2rem;
     border: none;
     border-radius: 0.4rem;
-    background-color: #1e88e5;
+    background: linear-gradient(#42a5f5, #1e88e5);
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
     color: #fff;
     outline: none;
     cursor: pointer;
+    transition: transform 0.1s;
 }
 
 button:active {
     transform: scale(0.98);
+}
+
+button:hover {
+    filter: brightness(1.1);
 }

--- a/js/gameScene.js
+++ b/js/gameScene.js
@@ -1,3 +1,13 @@
+const PIECE_COLORS = {
+    I: 0x00ffff,
+    J: 0x0000ff,
+    L: 0xff7f00,
+    O: 0xffff00,
+    S: 0x00ff00,
+    T: 0x800080,
+    Z: 0xff0000
+};
+
 class GameScene extends Phaser.Scene {
     constructor() {
         super({ key: 'GameScene' });
@@ -11,9 +21,13 @@ class GameScene extends Phaser.Scene {
         this.linesCleared = 0;
         this.dropInterval = 1000;
         this.lastDropTime = 0;
+        this.gridGraphics = null;
+        this.pieceGraphics = null;
     }
 
     create() {
+        this.gridGraphics = this.add.graphics();
+        this.pieceGraphics = this.add.graphics();
         this.initGrid();
         this.generatePieces();
         this.input.keyboard.on('keydown', this.handleKey, this);
@@ -174,11 +188,11 @@ class GameScene extends Phaser.Scene {
     }
 
     lockPiece() {
-        const { shape, x, y } = this.currentPiece;
+        const { shape, x, y, type } = this.currentPiece;
         for (let row = 0; row < shape.length; row++) {
             for (let col = 0; col < shape[row].length; col++) {
                 if (shape[row][col] && y + row >= 0) {
-                    this.grid[y + row][x + col] = 1;
+                    this.grid[y + row][x + col] = type;
                 }
             }
         }
@@ -215,27 +229,28 @@ class GameScene extends Phaser.Scene {
     }
 
     drawGrid() {
-        const graphics = this.add.graphics();
-        graphics.clear();
+        this.gridGraphics.clear();
         for (let row = 0; row < 20; row++) {
             for (let col = 0; col < 10; col++) {
                 if (this.grid[row][col]) {
-                    graphics.fillRect(col * 32, row * 32, 32, 32);
+                    const color = PIECE_COLORS[this.grid[row][col]] || 0xffffff;
+                    this.gridGraphics.fillStyle(color, 1);
+                    this.gridGraphics.fillRect(col * 32, row * 32, 32, 32);
                 }
-                graphics.lineStyle(1, 0x222222);
-                graphics.strokeRect(col * 32, row * 32, 32, 32);
+                this.gridGraphics.lineStyle(1, 0x222222);
+                this.gridGraphics.strokeRect(col * 32, row * 32, 32, 32);
             }
         }
     }
 
     drawPiece(piece) {
-        const graphics = this.add.graphics();
-        graphics.clear();
-        const { shape, x, y } = piece;
+        this.pieceGraphics.clear();
+        const { shape, x, y, type } = piece;
+        this.pieceGraphics.fillStyle(PIECE_COLORS[type], 1);
         for (let row = 0; row < shape.length; row++) {
             for (let col = 0; col < shape[row].length; col++) {
                 if (shape[row][col]) {
-                    graphics.fillRect((x + col) * 32, (y + row) * 32, 32, 32);
+                    this.pieceGraphics.fillRect((x + col) * 32, (y + row) * 32, 32, 32);
                 }
             }
         }

--- a/js/menuScene.js
+++ b/js/menuScene.js
@@ -6,7 +6,14 @@ class MenuScene extends Phaser.Scene {
     create() {
         const centerX = this.cameras.main.width / 2;
         const centerY = this.cameras.main.height / 2;
-        this.add.image(centerX, centerY - 200, 'logo').setScale(0.6);
+        if (this.textures.exists('logo')) {
+            this.add.image(centerX, centerY - 200, 'logo').setScale(0.6);
+        } else {
+            this.add.text(centerX, centerY - 200, 'TETRIS', {
+                fontSize: '48px',
+                color: '#fff'
+            }).setOrigin(0.5);
+        }
         const startButton = this.add.dom(centerX, centerY, 'button', null, 'ゲームスタート');
         startButton.addListener('click');
         startButton.on('click', () => {


### PR DESCRIPTION
## Summary
- refine styles with gradients and hover effects
- add logo fallback in `MenuScene`
- colorize pieces and reuse graphics objects

## Testing
- `node --check js/*.js`


------
https://chatgpt.com/codex/tasks/task_e_684d5ca40918832c83f9b98cd518bb67